### PR TITLE
Test case: Illustrates certificate chain validation failure.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 coverage/
+.idea
+*.iml

--- a/lib/flores/pki/csr.rb
+++ b/lib/flores/pki/csr.rb
@@ -142,11 +142,6 @@ module Flores::PKI
       certificate.issuer = extensions.issuer_certificate.subject
       certificate.add_extension(extensions.create_extension("subjectKeyIdentifier", "hash", false))
 
-      # RFC 5280 4.2.1.1. Authority Key Identifier
-      # This is "who signed this key"
-      certificate.add_extension(extensions.create_extension("authorityKeyIdentifier", "keyid:always", false))
-      #certificate.add_extension(extensions.create_extension("authorityKeyIdentifier", "keyid:always,issuer:always", false))
-
       if want_signature_ability?
         # Create a CA.
         certificate.add_extension(extensions.create_extension("basicConstraints", "CA:TRUE", true))


### PR DESCRIPTION
Test case to illustrate certficate chain validation failure when authorityKeyIdentifier is used.
WARNING - This commit contains a broken test, but the next commit will correct it.

bundle exec rspec spec/flores/pki_spec.rb :
Flores::PKI::CertificateSigningRequest certificate signed by an intermediate CA validates certificate chain

Illustrates #9